### PR TITLE
Support for APIs that runs inside another Rails application

### DIFF
--- a/lib/rack/api/app.rb
+++ b/lib/rack/api/app.rb
@@ -76,7 +76,7 @@ module Rack
       # Merge all params into one single hash.
       #
       def params
-        @params ||= HashWithIndifferentAccess.new(request.params.merge(env["rack.routing_args"]))
+        @params ||= HashWithIndifferentAccess.new(request.params.merge(env["rack.routing_args"]).merge(env["action_dispatch.request.request_parameters"] || {}))
       end
 
       # Return a request object.

--- a/spec/rack-api/params_spec.rb
+++ b/spec/rack-api/params_spec.rb
@@ -24,4 +24,9 @@ describe Rack::API, "Params" do
     post "/v1/users", :name => "John Doe"
     last_response.body.should == {"name" => "John Doe"}.to_json
   end
+
+  it "detects post params when running inside a rails app" do
+    post "/v1/users", {}, { "action_dispatch.request.request_parameters" => { :name => "John Doe" } }
+    last_response.body.should == {"name" => "John Doe"}.to_json
+  end
 end


### PR DESCRIPTION
In cases like this, action_dispatch.request.request_parameters is populated instead of rack.routing_args, so I just added it to Rack::API::App#params
