### PR TITLE
controller accepting empty options as default

### DIFF
--- a/lib/rack/api/controller.rb
+++ b/lib/rack/api/controller.rb
@@ -53,7 +53,7 @@ module Rack
       #
       attr_accessor :rescuers
 
-      def initialize(options)
+      def initialize(options = {})
         options.each do |name, value|
           instance_variable_set("@#{name}", value)
         end


### PR DESCRIPTION
nando, making controllers unit tests today requires us to set always the subject, because options argument doesn't have a default.

so I did this small change to make this easier. ;)
